### PR TITLE
chore(deps): update default registry's baseline to `4334d8b4c8916018600212ab4dd4bbdc343065d1`

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -2,7 +2,7 @@
   "$schema": "https://github.com/microsoft/vcpkg-tool/raw/refs/heads/main/docs/vcpkg-configuration.schema.json",
   "default-registry": {
     "kind": "builtin",
-    "baseline": "120deac3062162151622ca4860575a33844ba10b"
+    "baseline": "4334d8b4c8916018600212ab4dd4bbdc343065d1"
   },
   "registries": [
     {


### PR DESCRIPTION
This PR updates default registry's baseline to `4334d8b4c8916018600212ab4dd4bbdc343065d1`.